### PR TITLE
Add semantic mapping transformer to transform mapping for semantic felds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.x](https://github.com/opensearch-project/neural-search/compare/main...HEAD)
 ### Features
+- Support semantic field type to simplify neural search set up([#1225](https://github.com/opensearch-project/neural-search/pull/1225)).
 - Lower bound for min-max normalization technique in hybrid query ([#1195](https://github.com/opensearch-project/neural-search/pull/1195))
 - Support filter function for HybridQueryBuilder and NeuralQueryBuilder ([#1206](https://github.com/opensearch-project/neural-search/pull/1206))
 ### Enhancements

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -351,9 +351,9 @@ through the same build issue.
 
 ### Class and package names
 
-Class names should use `CamelCase`. 
+Class names should use `CamelCase`.
 
-Try to put new classes into existing packages if package name abstracts the purpose of the class. 
+Try to put new classes into existing packages if package name abstracts the purpose of the class.
 
 Example of good class file name and package utilization:
 
@@ -371,7 +371,7 @@ methods rather than a long single one and does everything.
 ### Documentation
 
 Document you code. That includes purpose of new classes, every public method and code sections that have critical or non-trivial
-logic (check this example https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java#L238). 
+logic (check this example https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java#L238).
 
 When you submit a feature PR, please submit a new
 [documentation issue](https://github.com/opensearch-project/documentation-website/issues/new/choose). This is a path for the documentation to be published as part of https://opensearch.org/docs/latest/ documentation site.
@@ -384,17 +384,17 @@ For the most part, we're using common conventions for Java projects. Here are a 
 
 1. Use descriptive names for classes, methods, fields, and variables.
 2. Avoid abbreviations unless they are widely accepted
-3. Use `final` on all method arguments unless it's absolutely necessary 
+3. Use `final` on all method arguments unless it's absolutely necessary
 4. Wildcard imports are not allowed.
 5. Static imports are preferred over qualified imports when using static methods
 6. Prefer creating non-static public methods whenever possible. Avoid static methods in general, as they can often serve as shortcuts.
 Static methods are acceptable if they are private and do not access class state.
-7. Use functional programming style inside methods unless it's a performance critical section. 
+7. Use functional programming style inside methods unless it's a performance critical section.
 8. For parameters of lambda expression please use meaningful names instead of shorten cryptic ones.
 9. Use Optional for return values if the value may not be present. This should be preferred to returning null.
 10. Do not create checked exceptions, and do not throw checked exceptions from public methods whenever possible. In general, if you call a method with a checked exception, you should wrap that exception into an unchecked exception.
 11. Throwing checked exceptions from private methods is acceptable.
-12. Use String.format when a string includes parameters, and prefer this over direct string concatenation. Always specify a Locale with String.format; 
+12. Use String.format when a string includes parameters, and prefer this over direct string concatenation. Always specify a Locale with String.format;
 as a rule of thumb, use Locale.ROOT.
 13. Prefer Lombok annotations to the manually written boilerplate code
 14. When throwing an exception, avoid including user-provided content in the exception message. For secure coding practices,
@@ -440,17 +440,17 @@ Fix any new warnings before submitting your PR to ensure proper code documentati
 
 ### Tests
 
-Write unit and integration tests for your new functionality. 
+Write unit and integration tests for your new functionality.
 
 Unit tests are preferred as they are cheap and fast, try to use them to cover all possible
-combinations of parameters. Utilize mocks to mimic dependencies. 
+combinations of parameters. Utilize mocks to mimic dependencies.
 
-Integration tests should be used sparingly, focusing primarily on the main (happy path) scenario or cases where extensive 
-mocking is impractical. Include one or two unhappy paths to confirm that correct response codes are returned to the user. 
-Whenever possible, favor scenarios that do not require model deployment. If model deployment is necessary, use an existing 
+Integration tests should be used sparingly, focusing primarily on the main (happy path) scenario or cases where extensive
+mocking is impractical. Include one or two unhappy paths to confirm that correct response codes are returned to the user.
+Whenever possible, favor scenarios that do not require model deployment. If model deployment is necessary, use an existing
 model, as tests involving new model deployments are the most resource-intensive.
 
-If your changes could affect backward compatibility, please include relevant backward compatibility tests along with your 
+If your changes could affect backward compatibility, please include relevant backward compatibility tests along with your
 PR. For guidance on adding these tests, refer to the [Backwards Compatibility Testing](#backwards-compatibility-testing) section in this guide.
 
 ### Outdated or irrelevant code

--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,7 @@ def knnJarDirectory = "$buildDir/dependencies/opensearch-knn"
 
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
+    implementation group: 'org.opensearch.plugin', name:'mapper-extras-client', version: "${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"

--- a/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
@@ -12,4 +12,13 @@ public class MappingConstants {
      * Name for the field type. In index mapping we use this key to define the field type.
      */
     public static final String TYPE = "type";
+    /**
+     * Name for doc. Actions like create index and legacy create/update index template will have the
+     * mapping properties under a _doc key.
+     */
+    public static final String DOC = "_doc";
+    /**
+     * Name for properties. An object field will define subfields as properties.
+     */
+    public static final String PROPERTIES = "properties";
 }

--- a/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+/**
+ * Constants related to the index mapping.
+ */
+public class MappingConstants {
+    /**
+     * Name for the field type. In index mapping we use this key to define the field type.
+     */
+    public static final String TYPE = "type";
+}

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+/**
+ * Constants for semantic field
+ */
+public class SemanticFieldConstants {
+    /**
+     * Name of the model id parameter. We use this key to define the id of the ML model that we will use for the
+     * semantic field.
+     */
+    public static final String MODEL_ID = "model_id";
+
+    /**
+     * Name of the search model id parameter. We use this key to define the id of the ML model that we will use to
+     * inference the query text during the search. If this parameter is not defined we will use the model_id instead.
+     */
+    public static final String SEARCH_MODEL_ID = "search_model_id";
+
+    /**
+     * Name of the raw field type parameter. We use this key to define the field type for the raw data. It will control
+     * how to store and query the raw data.
+     */
+    public static final String RAW_FIELD_TYPE = "raw_field_type";
+
+    /**
+     * Name of the raw field type parameter. We use this key to define a custom field name for the semantic info.
+     */
+    public static final String SEMANTIC_INFO_FIELD_NAME = "semantic_info_field_name";
+}

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -30,4 +30,9 @@ public class SemanticFieldConstants {
      * Name of the raw field type parameter. We use this key to define a custom field name for the semantic info.
      */
     public static final String SEMANTIC_INFO_FIELD_NAME = "semantic_info_field_name";
+
+    /**
+     * Default suffix for semantic info field name. It will be used to construct the field name of the semantic info.
+     */
+    public static final String DEFAULT_SEMANTIC_INFO_FIELD_NAME_SUFFIX = "_semantic_info";
 }

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+import org.opensearch.index.mapper.ObjectMapper;
+import org.opensearch.index.mapper.RankFeatureFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import reactor.util.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+
+/**
+ * Constants for semantic info
+ */
+public class SemanticInfoFieldConstants {
+    public static final String KNN_VECTOR_DIMENSION_FIELD_NAME = "dimension";
+    public static final String KNN_VECTOR_METHOD_FIELD_NAME = "method";
+    public static final String KNN_VECTOR_METHOD_ENGINE_FIELD_NAME = "engine";
+    public static final String KNN_VECTOR_METHOD_DEFAULT_ENGINE = "faiss";
+    public static final String KNN_VECTOR_METHOD_NAME_FIELD_NAME = "name";
+    public static final String KNN_VECTOR_METHOD_DEFAULT_NAME = "hnsw";
+    public static final String KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME = "space_type";
+
+    public static final String CHUNKS_FIELD_NAME = "chunks";
+    public static final String CHUNKS_TEXT_FIELD_NAME = "text";
+    public static final String CHUNKS_EMBEDDING_FIELD_NAME = "embedding";
+
+    public static final String MODEL_FIELD_NAME = "model";
+    public static final String MODEL_ID_FIELD_NAME = "id";
+    public static final String MODEL_NAME_FIELD_NAME = "name";
+    public static final String MODEL_TYPE_FIELD_NAME = "type";
+
+    public static final String INDEX_FIELD_NAME = "index";
+
+    // default model info field config will be text and we will not index it
+    private static final Map<String, Object> modelInfoFieldConfig = Map.of(
+        TYPE,
+        TextFieldMapper.CONTENT_TYPE,
+        INDEX_FIELD_NAME,
+        Boolean.FALSE
+    );
+    // default model info config which will have id, name and type
+    private static final Map<String, Object> modelConfig = Map.of(
+        PROPERTIES,
+        Map.of(
+            MODEL_ID_FIELD_NAME,
+            modelInfoFieldConfig,
+            MODEL_NAME_FIELD_NAME,
+            modelInfoFieldConfig,
+            MODEL_TYPE_FIELD_NAME,
+            modelInfoFieldConfig
+        )
+    );
+
+    public static Map<String, Object> getBaseSemanticInfoConfig(@NonNull final Map<String, Object> embeddingConfig) {
+        final Map<String, Object> chunksConfig = Map.of(
+            TYPE,
+            ObjectMapper.NESTED_CONTENT_TYPE,
+            PROPERTIES,
+            Map.of(CHUNKS_TEXT_FIELD_NAME, Map.of(TYPE, TextFieldMapper.CONTENT_TYPE), CHUNKS_EMBEDDING_FIELD_NAME, embeddingConfig)
+        );
+        return Map.of(PROPERTIES, Map.of(CHUNKS_FIELD_NAME, chunksConfig, MODEL_FIELD_NAME, modelConfig));
+    }
+
+    /**
+     * @return basic field config for text embedding field
+     */
+    public static Map<String, Object> getBaseTextEmbeddingConfig() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put(TYPE, KNNVectorFieldMapper.CONTENT_TYPE);
+        final Map<String, Object> methodConfig = new HashMap<>();
+        methodConfig.put(KNN_VECTOR_METHOD_ENGINE_FIELD_NAME, KNN_VECTOR_METHOD_DEFAULT_ENGINE);
+        methodConfig.put(KNN_VECTOR_METHOD_NAME_FIELD_NAME, KNN_VECTOR_METHOD_DEFAULT_NAME);
+        config.put(KNN_VECTOR_METHOD_FIELD_NAME, methodConfig);
+        return config;
+    }
+
+    /**
+     * @return basic field config for sparse embedding field
+     */
+    public static Map<String, Object> getBaseSparseEmbeddingConfig() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put(TYPE, RankFeatureFieldMapper.CONTENT_TYPE);
+        return config;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.TokenCountFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.neuralsearch.constants.MappingConstants;
+import org.opensearch.neuralsearch.mapper.semanticfieldtypes.SemanticFieldTypeFactory;
+import org.opensearch.neuralsearch.mapper.semanticfieldtypes.SemanticParameters;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+
+/**
+ * FieldMapper for the semantic field. It will hold a delegate field mapper to delegate the data parsing and query work
+ * based on the raw_field_type.
+ */
+public class SemanticFieldMapper extends ParametrizedFieldMapper {
+    public static final String CONTENT_TYPE = "semantic";
+    private final SemanticParameters semanticParameters;
+
+    @Setter
+    @Getter
+    private ParametrizedFieldMapper delegateFieldMapper;
+
+    protected SemanticFieldMapper(
+        String simpleName,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        ParametrizedFieldMapper delegateFieldMapper,
+        SemanticParameters semanticParameters
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.delegateFieldMapper = delegateFieldMapper;
+        this.semanticParameters = semanticParameters;
+    }
+
+    @Override
+    public Builder getMergeBuilder() {
+        Builder semanticFieldMapperBuilder = (Builder) new Builder(simpleName(), SemanticFieldTypeFactory.getInstance()).init(this);
+        ParametrizedFieldMapper.Builder delegateBuilder = delegateFieldMapper.getMergeBuilder();
+        semanticFieldMapperBuilder.setDelegateBuilder(delegateBuilder);
+        return semanticFieldMapperBuilder;
+    }
+
+    @Override
+    public final ParametrizedFieldMapper merge(Mapper mergeWith) {
+        if (mergeWith instanceof SemanticFieldMapper) {
+            try {
+                delegateFieldMapper = delegateFieldMapper.merge(((SemanticFieldMapper) mergeWith).delegateFieldMapper);
+            } catch (IllegalArgumentException e) {
+                String err = "Failed to update the mapper ["
+                    + this.name()
+                    + "] because failed to update the delegate "
+                    + "mapper for the raw_field_type "
+                    + this.semanticParameters.getRawFieldType()
+                    + ". "
+                    + e.getMessage();
+                throw new IllegalArgumentException(err, e);
+            }
+        }
+        return super.merge(mergeWith);
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        delegateFieldMapper.parse(context);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    public static class Builder extends ParametrizedFieldMapper.Builder {
+        @Getter
+        protected final Parameter<String> modelId = Parameter.stringParam(
+            MODEL_ID,
+            true,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getModelId(),
+            null
+        );
+        @Getter
+        protected final Parameter<String> searchModelId = Parameter.stringParam(
+            SEARCH_MODEL_ID,
+            true,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getSearchModelId(),
+            null
+        );
+        @Getter
+        protected final Parameter<String> rawFieldType = Parameter.stringParam(
+            RAW_FIELD_TYPE,
+            false,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getRawFieldType(),
+            TextFieldMapper.CONTENT_TYPE
+        );
+        @Getter
+        protected final Parameter<String> semanticInfoFieldName = Parameter.stringParam(
+            SEMANTIC_INFO_FIELD_NAME,
+            false,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getSemanticInfoFieldName(),
+            null
+        );
+
+        @Setter
+        protected ParametrizedFieldMapper.Builder delegateBuilder;
+        private final SemanticFieldTypeFactory semanticFieldTypeFactory;
+
+        protected Builder(String name, SemanticFieldTypeFactory semanticFieldTypeFactory) {
+            super(name);
+            this.semanticFieldTypeFactory = semanticFieldTypeFactory;
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return List.of(modelId, searchModelId, rawFieldType, semanticInfoFieldName);
+        }
+
+        @Override
+        public SemanticFieldMapper build(BuilderContext context) {
+            final ParametrizedFieldMapper delegateMapper = delegateBuilder.build(context);
+
+            final SemanticParameters semanticParameters = this.getSemanticParameters();
+            final MappedFieldType semanticFieldType = semanticFieldTypeFactory.createSemanticFieldType(
+                delegateMapper,
+                rawFieldType.getValue(),
+                semanticParameters
+            );
+
+            return new SemanticFieldMapper(
+                name,
+                semanticFieldType,
+                multiFieldsBuilder.build(this, context),
+                copyTo.build(),
+                delegateMapper,
+                semanticParameters
+            );
+        }
+
+        public SemanticParameters getSemanticParameters() {
+            return new SemanticParameters(
+                modelId.getValue(),
+                searchModelId.getValue(),
+                rawFieldType.getValue(),
+                semanticInfoFieldName.getValue()
+            );
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        private final static Set<String> SUPPORTED_RAW_FIELD_TYPE = Set.of(
+            TextFieldMapper.CONTENT_TYPE,
+            KeywordFieldMapper.CONTENT_TYPE,
+            MatchOnlyTextFieldMapper.CONTENT_TYPE,
+            WildcardFieldMapper.CONTENT_TYPE,
+            TokenCountFieldMapper.CONTENT_TYPE,
+            BinaryFieldMapper.CONTENT_TYPE
+        );
+
+        @Override
+        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            final String rawFieldType = (String) node.getOrDefault(RAW_FIELD_TYPE, TextFieldMapper.CONTENT_TYPE);
+
+            validateRawFieldType(rawFieldType);
+
+            final ParametrizedFieldMapper.TypeParser typeParser = (ParametrizedFieldMapper.TypeParser) parserContext.typeParser(
+                rawFieldType
+            );
+            final Builder semanticFieldMapperBuilder = new Builder(name, SemanticFieldTypeFactory.getInstance());
+
+            // semantic field mapper builder parse semantic fields
+            Map<String, Object> semanticConfig = extractSemanticConfig(node, semanticFieldMapperBuilder.getParameters(), rawFieldType);
+            semanticFieldMapperBuilder.parse(name, parserContext, semanticConfig);
+
+            // delegate field mapper builder parse remaining fields
+            ParametrizedFieldMapper.Builder delegateBuilder = typeParser.parse(name, node, parserContext);
+            semanticFieldMapperBuilder.setDelegateBuilder(delegateBuilder);
+
+            return semanticFieldMapperBuilder;
+        }
+
+        private void validateRawFieldType(final String rawFieldType) {
+            if (rawFieldType == null || !SUPPORTED_RAW_FIELD_TYPE.contains(rawFieldType)) {
+                throw new IllegalArgumentException(
+                    RAW_FIELD_TYPE
+                        + ": ["
+                        + rawFieldType
+                        + "] is not supported. It "
+                        + "should be one of ["
+                        + String.join(", ", SUPPORTED_RAW_FIELD_TYPE)
+                        + "]"
+                );
+            }
+        }
+
+        /**
+         * In this function we will extract all the parameters defined in the semantic field mapper builder and parse it
+         * later. The remaining parameters will be processed by the type parser of the raw field type. Here we cannot
+         * pass the parameters defined by semantic field to the delegate type parser of the raw field type because it
+         * cannot recognize them.
+         * @param node field config
+         * @param parameters parameters for semantic field
+         * @param rawFieldType field type of the raw data
+         * @return semantic field config
+         */
+        private Map<String, Object> extractSemanticConfig(Map<String, Object> node, List<Parameter<?>> parameters, String rawFieldType) {
+            final Map<String, Object> semanticConfig = new HashMap<>();
+            for (Parameter<?> parameter : parameters) {
+                Object config = node.get(parameter.name);
+                if (config != null) {
+                    semanticConfig.put(parameter.name, config);
+                    node.remove(parameter.name);
+                }
+            }
+            semanticConfig.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+            node.put(MappingConstants.TYPE, rawFieldType);
+            return semanticConfig;
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        builder.field(MappingConstants.TYPE, contentType());
+
+        // semantic parameters
+        final List<Parameter<?>> parameters = getMergeBuilder().getParameters();
+        for (Parameter<?> parameter : parameters) {
+            // By default, we will not return the default value. But raw_field_type is useful info to let users know how
+            // we will handle the raw data. So we explicitly return it even it is using the default value.
+            if (RAW_FIELD_TYPE.equals(parameter.name)) {
+                parameter.toXContent(builder, true);
+            } else {
+                parameter.toXContent(builder, includeDefaults);
+            }
+        }
+
+        // non-semantic parameters
+        // semantic field mapper itself does not handle multi fields or copy to. The delegate field mapper will handle it.
+        delegateFieldMapper.multiFields().toXContent(builder, params);
+        delegateFieldMapper.copyTo().toXContent(builder, params);
+        delegateFieldMapper.getMergeBuilder().toXContent(builder, includeDefaults);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldType.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.lucene.search.Query;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.lookup.SearchLookup;
+
+import java.time.ZoneId;
+import java.util.function.Supplier;
+
+/**
+ * A semantic field type that delegate the work to a mapped field type.
+ */
+public class SemanticFieldType extends MappedFieldType {
+    @Getter
+    private SemanticParameters semanticParameters;
+    protected MappedFieldType delegateFieldType;
+
+    public SemanticFieldType(@NonNull final MappedFieldType delegateFieldType, @NonNull final SemanticParameters semanticParameters) {
+        super(
+            delegateFieldType.name(),
+            delegateFieldType.isSearchable(),
+            delegateFieldType.isStored(),
+            delegateFieldType.hasDocValues(),
+            delegateFieldType.getTextSearchInfo(),
+            delegateFieldType.meta()
+        );
+        this.delegateFieldType = delegateFieldType;
+        this.semanticParameters = semanticParameters;
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(QueryShardContext queryShardContext, SearchLookup searchLookup, String format) {
+        return delegateFieldType.valueFetcher(queryShardContext, searchLookup, format);
+    }
+
+    @Override
+    public String typeName() {
+        return SemanticFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        return delegateFieldType.termQuery(value, context);
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+        return delegateFieldType.docValueFormat(format, timeZone);
+    }
+
+    @Override
+    public BytesReference valueForDisplay(Object value) {
+        return (BytesReference) delegateFieldType.valueForDisplay(value);
+    }
+
+    @Override
+    public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return delegateFieldType.fielddataBuilder(fullyQualifiedIndexName, searchLookup);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import lombok.NonNull;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.StringFieldType;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.TokenCountFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+
+import java.util.Set;
+
+/**
+ * A factory to create the semantic field type based on the raw field type.
+ */
+public class SemanticFieldTypeFactory {
+    private static final Set<String> STRING_FIELD_TYPES = Set.of(
+        TextFieldMapper.CONTENT_TYPE,
+        MatchOnlyTextFieldMapper.CONTENT_TYPE,
+        KeywordFieldMapper.CONTENT_TYPE,
+        WildcardFieldMapper.CONTENT_TYPE
+    );
+
+    private SemanticFieldTypeFactory() {
+        // Private constructor to prevent instantiation
+    }
+
+    private static class Holder {
+        private static final SemanticFieldTypeFactory INSTANCE = new SemanticFieldTypeFactory();
+    }
+
+    public static SemanticFieldTypeFactory getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    /**
+     * Create the semantic field type based on the raw field type.
+     * @param delegateMapper delegate field mapper
+     * @param rawFieldType field type for the raw data
+     * @param semanticParameters semantic parameters
+     * @return semantic field type
+     */
+    public MappedFieldType createSemanticFieldType(
+        @NonNull final ParametrizedFieldMapper delegateMapper,
+        @NonNull final String rawFieldType,
+        @NonNull final SemanticParameters semanticParameters
+    ) {
+        if (BinaryFieldMapper.CONTENT_TYPE.equals(rawFieldType)) {
+            return new SemanticFieldType(delegateMapper.fieldType(), semanticParameters);
+        } else if (STRING_FIELD_TYPES.contains(rawFieldType)) {
+            return new SemanticStringFieldType((StringFieldType) delegateMapper.fieldType(), semanticParameters);
+        } else if (TokenCountFieldMapper.CONTENT_TYPE.equals(rawFieldType)) {
+            return new SemanticNumberFieldType((NumberFieldMapper.NumberFieldType) delegateMapper.fieldType(), semanticParameters);
+        } else {
+            throw new IllegalArgumentException(
+                "Failed to create delegate field type for semantic field ["
+                    + delegateMapper.name()
+                    + "]. Unsupported raw field type: "
+                    + rawFieldType
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticNumberFieldType.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticNumberFieldType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.search.lookup.SearchLookup;
+
+/**
+ * A semantic field type that delegate the work to a number field type.
+ */
+public class SemanticNumberFieldType extends NumberFieldMapper.NumberFieldType {
+    @Getter
+    private SemanticParameters semanticParameters;
+    protected NumberFieldMapper.NumberFieldType delegateFieldType;
+
+    public SemanticNumberFieldType(
+        @NonNull final NumberFieldMapper.NumberFieldType delegateFieldType,
+        @NonNull final SemanticParameters semanticParameters
+    ) {
+        super(
+            delegateFieldType.name(),
+            delegateFieldType.numberType(),
+            delegateFieldType.isSearchable(),
+            delegateFieldType.isStored(),
+            delegateFieldType.hasDocValues(),
+            delegateFieldType.coerce(),
+            delegateFieldType.nullValue(),
+            delegateFieldType.meta()
+        );
+        this.delegateFieldType = delegateFieldType;
+        this.semanticParameters = semanticParameters;
+    }
+
+    @Override
+    public String typeName() {
+        return SemanticFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
+        return delegateFieldType.valueFetcher(context, searchLookup, format);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticParameters.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticParameters.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import lombok.Getter;
+
+/**
+ * A DTO to hold all the semantic parameters.
+ */
+@Getter
+public class SemanticParameters {
+    private final String modelId;
+    private final String searchModelId;
+    private final String rawFieldType;
+    private final String semanticInfoFieldName;
+
+    public SemanticParameters(String modelId, String searchModelId, String rawFieldType, String semanticInfoFieldName) {
+        this.modelId = modelId;
+        this.searchModelId = searchModelId;
+        this.semanticInfoFieldName = semanticInfoFieldName;
+        this.rawFieldType = rawFieldType;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticStringFieldType.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticStringFieldType.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.queries.intervals.IntervalsSource;
+import org.apache.lucene.queries.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.mapper.StringFieldType;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.IntervalMode;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A semantic field type that delegate the work to a string field type.
+ */
+public class SemanticStringFieldType extends StringFieldType {
+    @Getter
+    private SemanticParameters semanticParameters;
+    protected StringFieldType delegateFieldType;
+
+    public SemanticStringFieldType(@NonNull final StringFieldType delegateFieldType, @NonNull final SemanticParameters semanticParameters) {
+        super(
+            delegateFieldType.name(),
+            delegateFieldType.isSearchable(),
+            delegateFieldType.isStored(),
+            delegateFieldType.hasDocValues(),
+            delegateFieldType.getTextSearchInfo(),
+            delegateFieldType.meta()
+        );
+        this.delegateFieldType = delegateFieldType;
+        this.semanticParameters = semanticParameters;
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(QueryShardContext queryShardContext, SearchLookup searchLookup, String s) {
+        return delegateFieldType.valueFetcher(queryShardContext, searchLookup, s);
+    }
+
+    @Override
+    public String typeName() {
+        return SemanticFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        return delegateFieldType.prefixQuery(value, method, caseInsensitive, context);
+    }
+
+    @Override
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        return delegateFieldType.spanPrefixQuery(value, method, context);
+    }
+
+    @Override
+    public IntervalsSource intervals(String query, int max_gaps, IntervalMode mode, NamedAnalyzer analyzer, boolean prefix)
+        throws IOException {
+        return delegateFieldType.intervals(query, max_gaps, mode, analyzer, prefix);
+    }
+
+    @Override
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
+        return delegateFieldType.phraseQuery(stream, slop, enablePositionIncrements);
+    }
+
+    @Override
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
+        return delegateFieldType.multiPhraseQuery(stream, slop, enablePositionIncrements);
+    }
+
+    @Override
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) throws IOException {
+        return delegateFieldType.phrasePrefixQuery(stream, slop, maxExpansions);
+    }
+
+    @Override
+    public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return delegateFieldType.fielddataBuilder(fullyQualifiedIndexName, searchLookup);
+    }
+
+    @Override
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePosIncrements, QueryShardContext context) throws IOException {
+        return delegateFieldType.phraseQuery(stream, slop, enablePosIncrements, context);
+    }
+
+    @Override
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context)
+        throws IOException {
+        return delegateFieldType.multiPhraseQuery(stream, slop, enablePositionIncrements, context);
+    }
+
+    @Override
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions, QueryShardContext context) throws IOException {
+        return delegateFieldType.phrasePrefixQuery(stream, slop, maxExpansions, context);
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        return delegateFieldType.termQuery(value, context);
+    }
+
+    @Override
+    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        return delegateFieldType.termQueryCaseInsensitive(value, context);
+    }
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        MultiTermQuery.RewriteMethod method,
+        QueryShardContext context
+    ) {
+        return delegateFieldType.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions, method, context);
+    }
+
+    @Override
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        return delegateFieldType.wildcardQuery(value, method, caseInsensitive, context);
+    }
+
+    @Override
+    public Query regexpQuery(
+        String value,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        MultiTermQuery.RewriteMethod method,
+        QueryShardContext context
+    ) {
+        return delegateFieldType.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);
+    }
+
+    @Override
+    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        return delegateFieldType.rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        return delegateFieldType.termsQuery(values, context);
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        return delegateFieldType.valueForDisplay(value);
+    }
+
+    @Override
+    public BytesRef indexedValueForSearch(Object value) {
+        return delegateFieldType.indexedValueForSearch(value);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mappingtransformer;
+
+import com.google.common.annotations.VisibleForTesting;
+import joptsimple.internal.Strings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.MappingTransformer;
+
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.neuralsearch.constants.MappingConstants;
+import org.opensearch.neuralsearch.constants.SemanticFieldConstants;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import reactor.util.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.opensearch.neuralsearch.constants.MappingConstants.DOC;
+import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_DIMENSION_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.getBaseSemanticInfoConfig;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.getBaseSparseEmbeddingConfig;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.getBaseTextEmbeddingConfig;
+
+public class SemanticMappingTransformer implements MappingTransformer {
+    private final static Set<String> supportedModelAlgorithm = Set.of(
+        FunctionName.TEXT_EMBEDDING.name(),
+        FunctionName.REMOTE.name(),
+        FunctionName.SPARSE_ENCODING.name(),
+        FunctionName.SPARSE_TOKENIZE.name()
+    );
+    private final static Set<String> supportedRemoteModelTypes = Set.of(
+        FunctionName.TEXT_EMBEDDING.name(),
+        FunctionName.SPARSE_ENCODING.name(),
+        FunctionName.SPARSE_TOKENIZE.name()
+    );
+
+    private final MLCommonsClientAccessor mlClientAccessor;
+    private final NamedXContentRegistry xContentRegistry;
+
+    public SemanticMappingTransformer(
+        @NonNull final MLCommonsClientAccessor mlClientAccessor,
+        @NonNull final NamedXContentRegistry xContentRegistry
+    ) {
+        this.mlClientAccessor = mlClientAccessor;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    /**
+     * Add semantic info fields to the mapping.
+     * @param mapping original mapping
+     * e.g.
+     *{
+     *   "_doc": {
+     *     "properties": {
+     *       "semantic_field": {
+     *         "model_id": "model_id",
+     *         "type": "semantic"
+     *       }
+     *     }
+     *   }
+     * }
+     *
+     * It can be transformed to
+     *{
+     *   "_doc": {
+     *     "properties": {
+     *       "semantic_field": {
+     *         "model_id": "model_id",
+     *         "type": "semantic"
+     *       },
+     *       "semantic_field_semantic_info": {
+     *         "properties": {
+     *           "chunks": {
+     *             "type": "nested",
+     *             "properties": {
+     *               "embedding": {
+     *                 "type": "knn_vector",
+     *                 "dimension": 768,
+     *                 "method": {
+     *                   "engine": "faiss",
+     *                   "space_type": "l2",
+     *                   "name": "hnsw",
+     *                   "parameters": {}
+     *                 }
+     *               },
+     *               "text": {
+     *                 "type": "text"
+     *               }
+     *             }
+     *           },
+     *           "model": {
+     *             "properties": {
+     *               "id": {
+     *                 "type": "text",
+     *                 "index": false
+     *               },
+     *               "name": {
+     *                 "type": "text",
+     *                 "index": false
+     *               },
+     *               "type": {
+     *                 "type": "text",
+     *                 "index": false
+     *               }
+     *             }
+     *           }
+     *         }
+     *       }
+     *     }
+     *   }
+     * }
+     * @param context context to help transform
+     */
+
+    @Override
+    public void transform(Map<String, Object> mapping, TransformContext context, ActionListener<Void> listener) {
+        try {
+            final Map<String, Object> properties = getProperties(mapping);
+            // If there is no property or its format is not valid we simply do nothing and rely on core to validate the
+            // mappings and handle the error.
+            if (properties == null) {
+                listener.onResponse(null);
+                return;
+            }
+
+            Map<String, Map<String, Object>> semanticFieldPathToConfigMap = new HashMap<>();
+            String rootPath = Strings.EMPTY;
+            SemanticMappingUtils.collectSemanticField(properties, rootPath, semanticFieldPathToConfigMap);
+
+            fetchModelAndModifyMapping(semanticFieldPathToConfigMap, properties, listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getProperties(Map<String, Object> mapping) {
+        if (mapping == null) {
+            return null;
+        }
+        // Actions like create index and legacy create/update index template will have the mapping properties under a
+        // _doc key. Other actions like update mapping and create/update index template will not have the _doc layer.
+        if (mapping.containsKey(DOC) && mapping.get(DOC) instanceof Map) {
+            Map<String, Object> doc = (Map<String, Object>) mapping.get(DOC);
+            if (doc.containsKey(PROPERTIES) && doc.get(PROPERTIES) instanceof Map) {
+                return (Map<String, Object>) doc.get(PROPERTIES);
+            } else {
+                return null;
+            }
+        } else if (mapping.containsKey(PROPERTIES) && mapping.get(PROPERTIES) instanceof Map) {
+            return (Map<String, Object>) mapping.get(PROPERTIES);
+        } else {
+            return null;
+        }
+    }
+
+    private void fetchModelAndModifyMapping(
+        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap,
+        @NonNull final Map<String, Object> mappings,
+        @NonNull final ActionListener<Void> listener
+    ) {
+        final Map<String, List<String>> modelIdToFieldPathMap = SemanticMappingUtils.extractModelIdToFieldPathMap(
+            semanticFieldPathToConfigMap
+        );
+        if (modelIdToFieldPathMap.isEmpty()) {
+            listener.onResponse(null);
+        }
+        final AtomicInteger counter = new AtomicInteger(modelIdToFieldPathMap.size());
+
+        // we can have multiple semantic fields with different model ids and we should get model config for each model
+        for (String modelId : modelIdToFieldPathMap.keySet()) {
+            mlClientAccessor.getModel(modelId, new ActionListener<>() {
+                @Override
+                public void onResponse(MLModel mlModel) {
+                    try {
+                        synchronized (mappings) {
+                            modifyMappings(mappings, mlModel, modelIdToFieldPathMap.get(modelId), semanticFieldPathToConfigMap, modelId);
+                        }
+                        if (counter.decrementAndGet() == 0) {
+                            listener.onResponse(null);
+                        }
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    final String errorMessage = "Failed to transform mapping for semantic fields because failed to get "
+                        + "the model info of the model id "
+                        + modelId
+                        + ". "
+                        + e.getMessage();
+                    listener.onFailure(new RuntimeException(errorMessage, e));
+                }
+            });
+        }
+    }
+
+    private void modifyMappings(
+        @NonNull final Map<String, Object> mappings,
+        @NonNull final MLModel mlModel,
+        @NonNull final List<String> fieldPaths,
+        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap,
+        @NonNull final String modelId
+    ) {
+        for (String fieldPath : fieldPaths) {
+            final Map<String, Object> fieldConfig = semanticFieldPathToConfigMap.get(fieldPath);
+            final String baseErrorMessage = "Failed to transform the mapping for the semantic field with model id "
+                + modelId
+                + " at path "
+                + fieldPath
+                + ". ";
+            try {
+                final Map<String, Object> semanticInfoConfig = createSemanticInfoField(mlModel);
+                setSemanticInfoField(
+                    mappings,
+                    fieldPath,
+                    fieldConfig.get(SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME),
+                    semanticInfoConfig
+                );
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(baseErrorMessage + e.getMessage(), e);
+            } catch (Exception e) {
+                throw new RuntimeException(baseErrorMessage + e.getMessage(), e);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    private Map<String, Object> createSemanticInfoField(final @NonNull MLModel modelConfig) throws IOException {
+        final Map<String, Object> embeddingConfig = switch (modelConfig.getAlgorithm()) {
+            case FunctionName.TEXT_EMBEDDING -> createEmbeddingConfigForTextEmbeddingModel(modelConfig);
+            case FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE -> getBaseSparseEmbeddingConfig();
+            case FunctionName.REMOTE -> createEmbeddingConfigForRemoteModel(modelConfig);
+            default -> throw new IllegalArgumentException(
+                modelConfig.getAlgorithm().name()
+                    + " is not supported. The algorithm should be one of "
+                    + String.join(", ", supportedModelAlgorithm)
+            );
+        };
+
+        return getBaseSemanticInfoConfig(embeddingConfig);
+    }
+
+    private Map<String, Object> createEmbeddingConfigForRemoteModel(@NonNull final MLModel modelConfig) throws IOException {
+        final String modelType = modelConfig.getModelConfig().getModelType();
+        final FunctionName modelTypeFunctionName;
+
+        try {
+            modelTypeFunctionName = FunctionName.from(modelType);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(getUnsupportedRemoteModelError());
+        }
+
+        return switch (modelTypeFunctionName) {
+            case FunctionName.TEXT_EMBEDDING -> createEmbeddingConfigForTextEmbeddingModel(modelConfig);
+            case FunctionName.SPARSE_ENCODING, FunctionName.SPARSE_TOKENIZE -> getBaseSparseEmbeddingConfig();
+            default -> throw new IllegalArgumentException(getUnsupportedRemoteModelError());
+        };
+    }
+
+    private String getUnsupportedRemoteModelError() {
+        return "remote model type is not supported. It should be one of [" + String.join(", ", supportedRemoteModelTypes) + "].";
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> createEmbeddingConfigForTextEmbeddingModel(@NonNull final MLModel modelConfig) throws IOException {
+        final Map<String, Object> embeddingConfig = getBaseTextEmbeddingConfig();
+
+        if (!(modelConfig.getModelConfig() instanceof TextEmbeddingModelConfig textEmbeddingModelConfig)) {
+            throw new IllegalArgumentException("remote model is text embedding but model config is not a text embedding config.");
+        }
+
+        if (textEmbeddingModelConfig.getEmbeddingDimension() == null) {
+            throw new IllegalArgumentException(
+                "remote model is text embedding but embedding dimension is not defined " + "in the model config."
+            );
+        }
+        embeddingConfig.put(KNN_VECTOR_DIMENSION_FIELD_NAME, textEmbeddingModelConfig.getEmbeddingDimension());
+
+        final Map<String, Object> allConfigMap = MapperService.parseMapping(xContentRegistry, textEmbeddingModelConfig.getAllConfig());
+        final Object spaceTypeObject = allConfigMap.get(KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME);
+        if (!(spaceTypeObject instanceof String spaceTypeString)) {
+            throw new IllegalArgumentException("space_type is not defined or not a string in the all config of the model.");
+        }
+        final Map<String, Object> methodConfig = (Map<String, Object>) embeddingConfig.get(KNN_VECTOR_METHOD_FIELD_NAME);
+        methodConfig.put(KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME, spaceTypeString);
+
+        return embeddingConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setSemanticInfoField(
+        @NonNull final Map<String, Object> mappings,
+        @NonNull final String fullPath,
+        final Object userDefinedSemanticInfoFieldName,
+        @NonNull final Map<String, Object> semanticInfoConfig
+    ) {
+        if (userDefinedSemanticInfoFieldName != null && !(userDefinedSemanticInfoFieldName instanceof String)) {
+            throw new IllegalArgumentException(
+                SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME + " should be a string for the semantic field at: " + fullPath + "."
+            );
+        }
+        Map<String, Object> current = mappings;
+        final String[] paths = fullPath.split("\\.");
+        final String semanticInfoFieldName = userDefinedSemanticInfoFieldName == null
+            ? paths[paths.length - 1] + SemanticFieldConstants.DEFAULT_SEMANTIC_INFO_FIELD_NAME_SUFFIX
+            : (String) userDefinedSemanticInfoFieldName;
+        paths[paths.length - 1] = semanticInfoFieldName;
+        for (int i = 0; i < paths.length - 1; i++) {
+            final Map<String, Object> interFieldConfig = (Map<String, Object>) current.get(paths[i]);
+            current = (Map<String, Object>) interFieldConfig.get(MappingConstants.PROPERTIES);
+        }
+
+        // We simply set the whole semantic info config at the path of the semantic info. It is possible the config of
+        // semantic info fields can be invalid, but we will not validate it here. We will rely on field mappers to
+        // validate them when they parse the mappings.
+        current.put(semanticInfoFieldName, semanticInfoConfig);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mappingtransformer;
+
+import org.opensearch.neuralsearch.constants.MappingConstants;
+import org.opensearch.neuralsearch.constants.SemanticFieldConstants;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import reactor.util.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A util class to help process mapping with semantic field
+ */
+public class SemanticMappingUtils {
+    /**
+     * It will recursively traverse the mapping to collect the full path to field config map for semantic fields
+     * @param currentMapping current mapping
+     * @param parentPath path of the parent object
+     * @param semanticFieldPathToConfigMap path to field config map for semantic fields
+     */
+    @SuppressWarnings("unchecked")
+    public static void collectSemanticField(
+        @NonNull final Map<String, Object> currentMapping,
+        @NonNull final String parentPath,
+        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap
+    ) {
+        for (Map.Entry<String, Object> entry : currentMapping.entrySet()) {
+            final String fieldName = entry.getKey();
+            final Object fieldConfig = entry.getValue();
+
+            // Build the full path for the current field
+            final String fullPath = parentPath.isEmpty() ? fieldName : parentPath + "." + fieldName;
+
+            if (fieldConfig instanceof Map) {
+                final Map<String, Object> fieldConfigMap = (Map<String, Object>) fieldConfig;
+
+                if (isSemanticField(fieldConfigMap)) {
+                    semanticFieldPathToConfigMap.put(fullPath, fieldConfigMap);
+                }
+
+                // If it's an object field, recurse into the sub fields
+                if (fieldConfigMap.containsKey(MappingConstants.PROPERTIES)) {
+                    collectSemanticField(
+                        (Map<String, Object>) fieldConfigMap.get(MappingConstants.PROPERTIES),
+                        fullPath,
+                        semanticFieldPathToConfigMap
+                    );
+                }
+            }
+        }
+    }
+
+    private static boolean isSemanticField(Map<String, Object> fieldConfigMap) {
+        return fieldConfigMap.containsKey(MappingConstants.TYPE)
+            && SemanticFieldMapper.CONTENT_TYPE.equals(fieldConfigMap.get(MappingConstants.TYPE));
+    }
+
+    /**
+     * In mapping there can be multiple semantic fields with the same model id. This function can help build the model
+     * id to the path of semantic fields map. In this way we can know how many unique model ids we have and pull the
+     * model info for them.
+     * @param semanticFieldPathToConfigMap path to semantic field config map
+     * @return model id to paths of semantic fields map
+     */
+    public static Map<String, List<String>> extractModelIdToFieldPathMap(
+        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap
+    ) {
+        final Map<String, List<String>> modelIdToFieldPathMap = new HashMap<>();
+        for (Map.Entry<String, Map<String, Object>> entry : semanticFieldPathToConfigMap.entrySet()) {
+            final String fullPath = entry.getKey();
+            final Map<String, Object> fieldConfigMap = entry.getValue();
+            final String modelIdStr = getModelId(fieldConfigMap, fullPath);
+            if (modelIdToFieldPathMap.containsKey(modelIdStr)) {
+                modelIdToFieldPathMap.get(modelIdStr).add(fullPath);
+            } else {
+                modelIdToFieldPathMap.put(modelIdStr, new ArrayList<>());
+                modelIdToFieldPathMap.get(modelIdStr).add(fullPath);
+            }
+        }
+        return modelIdToFieldPathMap;
+    }
+
+    private static String getModelId(@NonNull final Map<String, Object> fieldConfigMap, @NonNull final String fullPath) {
+        final Object modelId = fieldConfigMap.get(SemanticFieldConstants.MODEL_ID);
+        if (!(modelId instanceof String)) {
+            throw new IllegalArgumentException("Model ID is a required string value for semantic field: " + fullPath);
+        }
+        return (String) modelId;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -17,6 +17,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
@@ -261,5 +262,9 @@ public class MLCommonsClientAccessor {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
         return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+    }
+
+    public void getModel(@NonNull final String modelId, @NonNull final ActionListener<MLModel> listener) {
+        mlClient.getModel(modelId, null, listener);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/util/FeatureFlagUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/FeatureFlagUtil.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import java.util.Map;
+
+public class FeatureFlagUtil {
+    public static final String SEMANTIC_FIELD_ENABLED = "semantic_field_enabled";
+    private static final Map<String, Boolean> featureFlagMap = Map.of(SEMANTIC_FIELD_ENABLED, Boolean.FALSE);
+
+    public static Boolean isEnabled(String name) {
+        return featureFlagMap.getOrDefault(name, Boolean.FALSE);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTestUtil.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTestUtil.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.NonNull;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.analysis.AnalyzerScope;
+import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.when;
+import static org.opensearch.Version.CURRENT;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+import static org.opensearch.test.OpenSearchTestCase.settings;
+
+public class SemanticFieldMapperTestUtil {
+    public static final String fieldName = "testField";
+    public static final String modelId = "modelId";
+    public static final String searchModelId = "searchModelId";
+    public static final String semanticInfoFieldName = "semanticInfoFieldName";
+
+    public static final SemanticFieldMapper.TypeParser TYPE_PARSER = new SemanticFieldMapper.TypeParser();
+    private static final IndexAnalyzers indexAnalyzers = new IndexAnalyzers(
+        singletonMap("default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
+        emptyMap(),
+        emptyMap()
+    );
+
+    public static Map<String, Object> createFieldConfig(final String rawFieldType) {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(RAW_FIELD_TYPE, rawFieldType);
+        node.put(MODEL_ID, modelId);
+        node.put(SEARCH_MODEL_ID, searchModelId);
+        node.put(SEMANTIC_INFO_FIELD_NAME, semanticInfoFieldName);
+        return node;
+    }
+
+    public static void mockParserContext(@NonNull final String rawFieldType, @NonNull final ParametrizedFieldMapper.TypeParser parser, @NonNull final Mapper.TypeParser.ParserContext parserContext) {
+        when(parserContext.typeParser(rawFieldType)).thenReturn(parser);
+        when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
+        when(parserContext.indexVersionCreated()).thenReturn(CURRENT);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapperWithTextAsRawFieldType(
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        final Map<String, Object> node = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        return buildSemanticFieldMapperWithTextAsRawFieldType(node, parserContext);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapperWithTextAsRawFieldType(
+        final @NonNull Map<String, Object> fieldConfig,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        return buildSemanticFieldMapper(fieldConfig, TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapper(
+        final @NonNull String rawFieldType,
+        final @NonNull ParametrizedFieldMapper.TypeParser typeParser,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        final Map<String, Object> fieldConfig = createFieldConfig(rawFieldType);
+        return buildSemanticFieldMapper(fieldConfig, rawFieldType, typeParser, parserContext);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapper(
+        final @NonNull Map<String, Object> fieldConfig,
+        final @NonNull String rawFieldType,
+        final @NonNull ParametrizedFieldMapper.TypeParser typeParser,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        mockParserContext(rawFieldType, typeParser, parserContext);
+
+        final SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, fieldConfig, parserContext);
+
+        final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        final ParametrizedFieldMapper.BuilderContext builderContext = new ParametrizedFieldMapper.BuilderContext(
+            settings,
+            new ContentPath()
+        );
+
+        return builder.build(builderContext);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.NonNull;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.neuralsearch.mapper.semanticfieldtypes.SemanticFieldTypeFactory;
+import org.opensearch.neuralsearch.mapper.semanticfieldtypes.SemanticStringFieldType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapperWithTextAsRawFieldType;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.mockParserContext;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.TYPE_PARSER;
+import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
+
+public class SemanticFieldMapperTests extends OpenSearchTestCase {
+
+    @Mock
+    private ParametrizedFieldMapper.TypeParser.ParserContext parserContext;
+    @Mock
+    private ParseContext parseContext;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testTypeParser_parse_whenTextRawFieldType_thenDelegateTextFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(TextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenMatchOnlyTextRawFieldType_thenDelegateTextOnlyFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(MatchOnlyTextFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(MatchOnlyTextFieldMapper.CONTENT_TYPE, MatchOnlyTextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(MatchOnlyTextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof MatchOnlyTextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenKeywordRawFieldType_thenDelegateKeywordFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(KeywordFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(KeywordFieldMapper.CONTENT_TYPE, KeywordFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(KeywordFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof KeywordFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenWildcardRawFieldType_thenDelegateWildcardFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(WildcardFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(WildcardFieldMapper.CONTENT_TYPE, WildcardFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(WildcardFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof WildcardFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenBinaryRawFieldType_thenDelegateBinaryFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(BinaryFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(BinaryFieldMapper.CONTENT_TYPE, BinaryFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(BinaryFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof BinaryFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenNoRawFieldType_thenDelegateTextFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(null);
+        node.remove(RAW_FIELD_TYPE);
+
+        mockParserContext(TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(TextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenNullRawFieldType_thenException() {
+        final Map<String, Object> node = createFieldConfig(null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext)
+        );
+        final String expectedError = "raw_field_type: [null] is not supported. It should be one of";
+        assertTrue(exception.getMessage().contains(expectedError));
+    }
+
+    public void testTypeParser_parse_whenUnsupportedRawFieldType_thenException() {
+        final Map<String, Object> node = createFieldConfig("unsupported");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext)
+        );
+        final String expectedError = "raw_field_type: [unsupported] is not supported. It should be one of";
+        assertTrue(exception.getMessage().contains(expectedError));
+    }
+
+    private void assertBuilderParseParametersSuccessfully(
+        @NonNull final String rawFieldType,
+        @NonNull final SemanticFieldMapper.Builder builder
+    ) {
+        assertEquals(rawFieldType, builder.rawFieldType.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.modelId, builder.modelId.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.searchModelId, builder.searchModelId.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.semanticInfoFieldName, builder.semanticInfoFieldName.getValue());
+    }
+
+    private Map<String, Object> createFieldConfig(final String rawFieldType) {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(RAW_FIELD_TYPE, rawFieldType);
+        node.put(MODEL_ID, SemanticFieldMapperTestUtil.modelId);
+        node.put(SEARCH_MODEL_ID, SemanticFieldMapperTestUtil.searchModelId);
+        node.put(SEMANTIC_INFO_FIELD_NAME, SemanticFieldMapperTestUtil.semanticInfoFieldName);
+        return node;
+    }
+
+    public void testBuilder_getParameters() {
+        final SemanticFieldMapper.Builder builder = new SemanticFieldMapper.Builder(
+            SemanticFieldMapperTestUtil.fieldName,
+            SemanticFieldTypeFactory.getInstance()
+        );
+        assertEquals(4, builder.getParameters().size());
+        List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
+        List<String> expectedParams = Arrays.asList(MODEL_ID, SEARCH_MODEL_ID, RAW_FIELD_TYPE, SEMANTIC_INFO_FIELD_NAME);
+        assertEquals(expectedParams, actualParams);
+    }
+
+    public void testBuilder_build_shouldBuildDelegateFieldMapper() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        assertTrue(semanticFieldMapper.getDelegateFieldMapper() instanceof TextFieldMapper);
+        assertTrue(semanticFieldMapper.fieldType() instanceof SemanticStringFieldType);
+    }
+
+    public void testFieldMapper_getMergeBuilder_shouldSetDelegateMergeBuilder() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        final SemanticFieldMapper.Builder mergeBuilder = semanticFieldMapper.getMergeBuilder();
+        assertTrue(mergeBuilder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testFieldMapper_merge_shouldMergeDelegateFieldMapper() {
+        final String newModelId = "newModelId";
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(MODEL_ID, newModelId);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final SemanticFieldMapper mergedSemanticFieldMapper = (SemanticFieldMapper) semanticFieldMapper.merge(semanticFieldMapperToMerge);
+
+        assertEquals(newModelId, mergedSemanticFieldMapper.getMergeBuilder().modelId.getValue());
+        // A new delegate field mapper should be created after the merge and it's still a text field mapper
+        assertNotEquals(semanticFieldMapper.getDelegateFieldMapper(), mergedSemanticFieldMapper.getDelegateFieldMapper());
+        assertTrue(mergedSemanticFieldMapper.getDelegateFieldMapper() instanceof TextFieldMapper);
+    }
+
+    public void testFieldMapper_merge_whenConflictWithSemanticParameters_thenException() {
+        final String newSemanticInfoFieldName = "newSemanticInfoFieldName";
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(SEMANTIC_INFO_FIELD_NAME, newSemanticInfoFieldName);
+        when(parserContext.typeParser(KeywordFieldMapper.CONTENT_TYPE)).thenReturn(KeywordFieldMapper.PARSER);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> semanticFieldMapper.merge(semanticFieldMapperToMerge)
+        );
+
+        final String expectedError = "Mapper for [testField] conflicts with existing mapper:\n"
+            + "\tCannot update parameter [semantic_info_field_name] from [semanticInfoFieldName] to [newSemanticInfoFieldName]";
+        assertEquals(expectedError, exception.getMessage());
+    }
+
+    public void testFieldMapper_merge_whenConflictWithDelegateMapperParameters_thenException() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(RAW_FIELD_TYPE, KeywordFieldMapper.CONTENT_TYPE);
+        when(parserContext.typeParser(KeywordFieldMapper.CONTENT_TYPE)).thenReturn(KeywordFieldMapper.PARSER);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> semanticFieldMapper.merge(semanticFieldMapperToMerge)
+        );
+
+        final String expectedError = "Failed to update the mapper [testField] because failed to update the delegate mapper for the "
+            + "raw_field_type text. mapper [testField] cannot be changed from type [text] to [keyword]";
+        assertEquals(expectedError, exception.getMessage());
+    }
+
+    public void testFieldMapper_parseCreateField_shouldDelegateToDelegateMapper() throws IOException {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        ParametrizedFieldMapper delegateMapper = mock(ParametrizedFieldMapper.class);
+        semanticFieldMapper.setDelegateFieldMapper(delegateMapper);
+
+        semanticFieldMapper.parseCreateField(parseContext);
+
+        verify(delegateMapper, times(1)).parse(parseContext);
+    }
+
+    public void testFieldMapper_contentType_shouldReturnSemantic() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        assertEquals(SemanticFieldMapper.CONTENT_TYPE, semanticFieldMapper.contentType());
+    }
+
+    public void testFieldMapper_doXContentBody_shouldReturnParameters() throws IOException {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        final XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        semanticFieldMapper.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        final Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        final Map<String, Object> expected = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        assertEquals(expected, out);
+    }
+
+    public void testFieldMapper_doXContentBody_withDefaultRawFieldType_shouldReturnDefaultValue() throws IOException {
+        final Map<String, Object> config = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        config.remove(RAW_FIELD_TYPE);
+
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(config, parserContext);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        semanticFieldMapper.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        Map<String, Object> expected = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        assertEquals(expected, out);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeFactoryTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.TokenCountFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapper;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapperWithTextAsRawFieldType;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.createFieldConfig;
+
+public class SemanticFieldTypeFactoryTests extends OpenSearchTestCase {
+    private final SemanticFieldTypeFactory semanticFieldTypeFactory = SemanticFieldTypeFactory.getInstance();
+    @Mock
+    private Mapper.TypeParser.ParserContext parserContext;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testCreateSemanticFieldType_whenBinaryAsRawFieldType_thenSemanticFieldType() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            BinaryFieldMapper.CONTENT_TYPE,
+            BinaryFieldMapper.PARSER,
+            parserContext
+        );
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            BinaryFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenTextAsRawFieldType_thenSemanticStringFieldType() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            TextFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticStringFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenMatchOnlyTextAsRawFieldType_thenSemanticStringFieldType() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            MatchOnlyTextFieldMapper.CONTENT_TYPE,
+            MatchOnlyTextFieldMapper.PARSER,
+            parserContext
+        );
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            MatchOnlyTextFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticStringFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenKeywordAsRawFieldType_thenSemanticStringFieldType() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            KeywordFieldMapper.CONTENT_TYPE,
+            KeywordFieldMapper.PARSER,
+            parserContext
+        );
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            KeywordFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticStringFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenWildcardAsRawFieldType_thenSemanticStringFieldType() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            WildcardFieldMapper.CONTENT_TYPE,
+            WildcardFieldMapper.PARSER,
+            parserContext
+        );
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            WildcardFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticStringFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenTokenCountAsRawFieldType_thenSemanticNumberFieldType() {
+        final Map<String, Object> fieldConfig = createFieldConfig(TokenCountFieldMapper.CONTENT_TYPE);
+        fieldConfig.put("analyzer", "default");
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            fieldConfig,
+            TokenCountFieldMapper.CONTENT_TYPE,
+            TokenCountFieldMapper.PARSER,
+            parserContext
+        );
+
+        final MappedFieldType fieldType = semanticFieldTypeFactory.createSemanticFieldType(
+            semanticFieldMapper,
+            TokenCountFieldMapper.CONTENT_TYPE,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+
+        assertTrue(fieldType instanceof SemanticNumberFieldType);
+    }
+
+    public void testCreateSemanticFieldType_whenUnsupportedRawFieldType_thenException() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> semanticFieldTypeFactory.createSemanticFieldType(
+                semanticFieldMapper,
+                "unsupported",
+                semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+            )
+        );
+
+        final String expectedErrorMessage = "Failed to create delegate field type for semantic field [testField]. "
+            + "Unsupported raw field type: unsupported";
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticFieldTypeTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapper;
+
+public class SemanticFieldTypeTests extends OpenSearchTestCase {
+    @Mock
+    private Mapper.TypeParser.ParserContext parserContext;
+    @Mock
+    private MappedFieldType mockDelegateFieldType;
+    private SemanticFieldType semanticFieldType;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            BinaryFieldMapper.CONTENT_TYPE,
+            BinaryFieldMapper.PARSER,
+            parserContext
+        );
+        final MappedFieldType mappedFieldType = semanticFieldMapper.getDelegateFieldMapper().fieldType();
+
+        when(mockDelegateFieldType.name()).thenReturn(mappedFieldType.name());
+        when(mockDelegateFieldType.isSearchable()).thenReturn(mappedFieldType.isSearchable());
+        when(mockDelegateFieldType.isStored()).thenReturn(mappedFieldType.isStored());
+        when(mockDelegateFieldType.hasDocValues()).thenReturn(mappedFieldType.hasDocValues());
+        when(mockDelegateFieldType.getTextSearchInfo()).thenReturn(mappedFieldType.getTextSearchInfo());
+        when(mockDelegateFieldType.meta()).thenReturn(mappedFieldType.meta());
+
+        semanticFieldType = new SemanticFieldType(mockDelegateFieldType, semanticFieldMapper.getMergeBuilder().getSemanticParameters());
+    }
+
+    public void testSemanticFieldType_shouldDelegateWork() throws IOException {
+        assertEquals(SemanticFieldMapper.CONTENT_TYPE, semanticFieldType.typeName());
+
+        semanticFieldType.valueFetcher(any(), any(), any());
+        verify(mockDelegateFieldType, times(1)).valueFetcher(any(), any(), any());
+
+        semanticFieldType.termQuery(any(), any());
+        verify(mockDelegateFieldType, times(1)).termQuery(any(), any());
+
+        semanticFieldType.docValueFormat(any(), any());
+        verify(mockDelegateFieldType, times(1)).docValueFormat(any(), any());
+
+        semanticFieldType.valueForDisplay(any());
+        verify(mockDelegateFieldType, times(1)).valueForDisplay(any());
+
+        semanticFieldType.fielddataBuilder(any(), any());
+        verify(mockDelegateFieldType, times(1)).fielddataBuilder(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticNumberFieldTypeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticNumberFieldTypeTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.TokenCountFieldMapper;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapper;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.createFieldConfig;
+
+public class SemanticNumberFieldTypeTests extends OpenSearchTestCase {
+    @Mock
+    private Mapper.TypeParser.ParserContext parserContext;
+    @Mock
+    private NumberFieldMapper.NumberFieldType mockDelegateFieldType;
+    private SemanticNumberFieldType semanticNumberFieldType;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        final Map<String, Object> fieldConfig = createFieldConfig(TokenCountFieldMapper.CONTENT_TYPE);
+        fieldConfig.put("analyzer", "default");
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(
+            fieldConfig,
+            TokenCountFieldMapper.CONTENT_TYPE,
+            TokenCountFieldMapper.PARSER,
+            parserContext
+        );
+
+        final NumberFieldMapper.NumberFieldType numberFieldType = (NumberFieldMapper.NumberFieldType) semanticFieldMapper
+            .getDelegateFieldMapper()
+            .fieldType();
+
+        Mockito.when(mockDelegateFieldType.name()).thenReturn(numberFieldType.name());
+        Mockito.when(mockDelegateFieldType.numberType()).thenReturn(numberFieldType.numberType());
+        Mockito.when(mockDelegateFieldType.isSearchable()).thenReturn(numberFieldType.isSearchable());
+        Mockito.when(mockDelegateFieldType.isStored()).thenReturn(numberFieldType.isStored());
+        Mockito.when(mockDelegateFieldType.hasDocValues()).thenReturn(numberFieldType.hasDocValues());
+        Mockito.when(mockDelegateFieldType.coerce()).thenReturn(numberFieldType.coerce());
+        Mockito.when(mockDelegateFieldType.nullValue()).thenReturn(numberFieldType.nullValue());
+        Mockito.when(mockDelegateFieldType.meta()).thenReturn(numberFieldType.meta());
+
+        semanticNumberFieldType = new SemanticNumberFieldType(
+            mockDelegateFieldType,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+    }
+
+    public void testSemanticNumberFieldType_shouldDelegateWork() {
+        assertEquals(SemanticFieldMapper.CONTENT_TYPE, semanticNumberFieldType.typeName());
+
+        semanticNumberFieldType.valueFetcher(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(mockDelegateFieldType, Mockito.times(1)).valueFetcher(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticStringFieldTypeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/semanticfieldtypes/SemanticStringFieldTypeTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.semanticfieldtypes;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.StringFieldType;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapperWithTextAsRawFieldType;
+
+public class SemanticStringFieldTypeTests extends OpenSearchTestCase {
+    @Mock
+    private Mapper.TypeParser.ParserContext parserContext;
+    @Mock
+    private StringFieldType mockDelegateFieldType;
+    private SemanticStringFieldType semanticStringFieldType;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        final StringFieldType stringFieldType = (StringFieldType) semanticFieldMapper.getDelegateFieldMapper().fieldType();
+
+        when(mockDelegateFieldType.name()).thenReturn(stringFieldType.name());
+        when(mockDelegateFieldType.isSearchable()).thenReturn(stringFieldType.isSearchable());
+        when(mockDelegateFieldType.isStored()).thenReturn(stringFieldType.isStored());
+        when(mockDelegateFieldType.hasDocValues()).thenReturn(stringFieldType.hasDocValues());
+        when(mockDelegateFieldType.getTextSearchInfo()).thenReturn(stringFieldType.getTextSearchInfo());
+        when(mockDelegateFieldType.meta()).thenReturn(stringFieldType.meta());
+
+        semanticStringFieldType = new SemanticStringFieldType(
+            mockDelegateFieldType,
+            semanticFieldMapper.getMergeBuilder().getSemanticParameters()
+        );
+    }
+
+    public void testSemanticStringFieldType_shouldDelegateWork() throws IOException {
+        assertEquals(SemanticFieldMapper.CONTENT_TYPE, semanticStringFieldType.typeName());
+
+        semanticStringFieldType.valueFetcher(any(), any(), any());
+        verify(mockDelegateFieldType, times(1)).valueFetcher(any(), any(), any());
+
+        semanticStringFieldType.prefixQuery(any(), any(), anyBoolean(), any());
+        verify(mockDelegateFieldType, times(1)).prefixQuery(any(), any(), anyBoolean(), any());
+
+        semanticStringFieldType.spanPrefixQuery(any(), any(), any());
+        verify(mockDelegateFieldType, times(1)).spanPrefixQuery(any(), any(), any());
+
+        semanticStringFieldType.intervals(any(), anyInt(), any(), any(), anyBoolean());
+        verify(mockDelegateFieldType, times(1)).intervals(any(), anyInt(), any(), any(), anyBoolean());
+
+        semanticStringFieldType.phraseQuery(any(), anyInt(), anyBoolean());
+        verify(mockDelegateFieldType, times(1)).phraseQuery(any(), anyInt(), anyBoolean());
+
+        semanticStringFieldType.multiPhraseQuery(any(), anyInt(), anyBoolean());
+        verify(mockDelegateFieldType, times(1)).multiPhraseQuery(any(), anyInt(), anyBoolean());
+
+        semanticStringFieldType.phrasePrefixQuery(any(), anyInt(), anyInt());
+        verify(mockDelegateFieldType, times(1)).phrasePrefixQuery(any(), anyInt(), anyInt());
+
+        semanticStringFieldType.fielddataBuilder(any(), any());
+        verify(mockDelegateFieldType, times(1)).fielddataBuilder(any(), any());
+
+        semanticStringFieldType.phraseQuery(any(), anyInt(), anyBoolean(), any());
+        verify(mockDelegateFieldType, times(1)).phraseQuery(any(), anyInt(), anyBoolean(), any());
+
+        semanticStringFieldType.multiPhraseQuery(any(), anyInt(), anyBoolean(), any());
+        verify(mockDelegateFieldType, times(1)).multiPhraseQuery(any(), anyInt(), anyBoolean(), any());
+
+        semanticStringFieldType.phrasePrefixQuery(any(), anyInt(), anyInt(), any());
+        verify(mockDelegateFieldType, times(1)).phrasePrefixQuery(any(), anyInt(), anyInt(), any());
+
+        semanticStringFieldType.termQuery(any(), any());
+        verify(mockDelegateFieldType, times(1)).termQuery(any(), any());
+
+        semanticStringFieldType.termQueryCaseInsensitive(any(), any());
+        verify(mockDelegateFieldType, times(1)).termQuery(any(), any());
+
+        semanticStringFieldType.fuzzyQuery(any(), any(), anyInt(), anyInt(), anyBoolean(), any(), any());
+        verify(mockDelegateFieldType, times(1)).fuzzyQuery(any(), any(), anyInt(), anyInt(), anyBoolean(), any(), any());
+
+        semanticStringFieldType.wildcardQuery(any(), any(), anyBoolean(), any());
+        verify(mockDelegateFieldType, times(1)).wildcardQuery(any(), any(), anyBoolean(), any());
+
+        semanticStringFieldType.regexpQuery(any(), anyInt(), anyInt(), anyInt(), any(), any());
+        verify(mockDelegateFieldType, times(1)).regexpQuery(any(), anyInt(), anyInt(), anyInt(), any(), any());
+
+        semanticStringFieldType.rangeQuery(any(), any(), anyBoolean(), anyBoolean(), any());
+        verify(mockDelegateFieldType, times(1)).rangeQuery(any(), any(), anyBoolean(), anyBoolean(), any());
+
+        semanticStringFieldType.termsQuery(any(), any());
+        verify(mockDelegateFieldType, times(1)).termsQuery(any(), any());
+
+        semanticStringFieldType.valueForDisplay(any());
+        verify(mockDelegateFieldType, times(1)).valueForDisplay(any());
+
+        semanticStringFieldType.indexedValueForSearch(any());
+        verify(mockDelegateFieldType, times(1)).indexedValueForSearch(any());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformerTests.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mappingtransformer;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.QuestionAnsweringModelConfig;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
+import org.opensearch.neuralsearch.constants.MappingConstants;
+import org.opensearch.neuralsearch.constants.SemanticFieldConstants;
+import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.test.OpenSearchTestCase;
+import reactor.util.annotation.NonNull;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+public class SemanticMappingTransformerTests extends OpenSearchTestCase {
+    @Mock
+    private MLCommonsClientAccessor mlClientAccessor;
+
+    private NamedXContentRegistry namedXContentRegistry;
+
+    @Mock
+    private ActionListener<Void> listener;
+
+    private SemanticMappingTransformer transformer;
+    private final ClassLoader classLoader = this.getClass().getClassLoader();
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());
+        transformer = new SemanticMappingTransformer(mlClientAccessor, namedXContentRegistry);
+    }
+
+    public void testTransform_whenMappingNull_thenDoNothing() {
+        transformer.transform(null, null, listener);
+
+        verify(listener).onResponse(null);
+    }
+
+    public void testTransform_whenUnexpectedMappingFormat_thenDoNothing() {
+        final Map<String, Object> unexpectedMapping = new HashMap<>();
+        unexpectedMapping.put("properties", "value");
+        transformer.transform(unexpectedMapping, null, listener);
+
+        verify(listener).onResponse(null);
+    }
+
+    public void testTransform_whenNoSemanticField_thenDoNothing() {
+        final Map<String, Object> unexpectedMapping = new HashMap<>();
+        unexpectedMapping.put("properties", Map.of("field", Map.of("type", "text")));
+
+        transformer.transform(unexpectedMapping, null, listener);
+
+        verify(listener).onResponse(null);
+    }
+
+    public void testTransform_whenSemanticFields_thenTransformMappingsSuccessfully() throws URISyntaxException, IOException {
+        // prepare original mappings
+        final String textEmbeddingModelId = "textEmbeddingModelId";
+        final String sparseModelId = "sparseModelId";
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticFiled1 = new HashMap<>();
+        properties.put("semantic_field_1", semanticFiled1);
+        semanticFiled1.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled1.put(SemanticFieldConstants.MODEL_ID, textEmbeddingModelId);
+
+        final String customSemanticInfoFieldName = "custom_semantic_info_field";
+        final Map<String, Object> semanticFiled2 = new HashMap<>();
+        properties.put("semantic_field_2", semanticFiled2);
+        semanticFiled2.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled2.put(SemanticFieldConstants.MODEL_ID, sparseModelId);
+        semanticFiled2.put(SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME, customSemanticInfoFieldName);
+
+        // prepare mock model config
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{\"space_type\":\"l2\"}";
+        final TextEmbeddingModelConfig textEmbeddingModelConfig = TextEmbeddingModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType("modelType")
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+        final MLModel textEmbeddingModel = MLModel.builder()
+            .algorithm(FunctionName.TEXT_EMBEDDING)
+            .modelConfig(textEmbeddingModelConfig)
+            .build();
+
+        final MLModel sparseModel = MLModel.builder().algorithm(FunctionName.SPARSE_ENCODING).build();
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (textEmbeddingModelId.equals(modelId)) {
+                listener.onResponse(textEmbeddingModel);
+            } else if (sparseModelId.equals(modelId)) {
+                listener.onResponse(sparseModel);
+            } else {
+                listener.onFailure(new RuntimeException("Model not found"));
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // verify
+        final String expectedTransformedMappingString = Files.readString(
+            Path.of(classLoader.getResource("mapper/transformedMappingMultipleSemanticFields.json").toURI())
+        );
+
+        final Map<String, Object> expectedTransformedMapping = MapperService.parseMapping(
+            namedXContentRegistry,
+            expectedTransformedMappingString
+        );
+        assertEquals(expectedTransformedMapping, mappings);
+    }
+
+    public void testTransform_whenSemanticFieldsWithRemoteModels_thenTransformMappingsSuccessfully() throws URISyntaxException,
+        IOException {
+        // prepare original mappings
+        final String remoteTextEmbeddingModelId = "textEmbeddingModelId";
+        final String remoteSparseModelId = "sparseModelId";
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticFiled1 = new HashMap<>();
+        properties.put("semantic_field_1", semanticFiled1);
+        semanticFiled1.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled1.put(SemanticFieldConstants.MODEL_ID, remoteTextEmbeddingModelId);
+
+        final String customSemanticInfoFieldName = "custom_semantic_info_field";
+        final Map<String, Object> semanticFiled2 = new HashMap<>();
+        properties.put("semantic_field_2", semanticFiled2);
+        semanticFiled2.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled2.put(SemanticFieldConstants.MODEL_ID, remoteSparseModelId);
+        semanticFiled2.put(SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME, customSemanticInfoFieldName);
+
+        // prepare mock model config
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{\"space_type\":\"l2\"}";
+        final TextEmbeddingModelConfig remoteTextEmbeddingModelConfig = TextEmbeddingModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+        final MLModel remoteTextEmbeddingModel = MLModel.builder()
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteTextEmbeddingModelConfig)
+            .build();
+
+        // Currently there is no dedicated model config for remote model and we are using TextEmbeddingModelConfig
+        // in ml-common. Once ml-common created a dedicated one we should replace it.
+        final MLModelConfig remoteSparseModelConfig = TextEmbeddingModelConfig.builder()
+            .embeddingDimension(0) // This is required for TextEmbeddingModelConfig even we don't need it for the remote sparse model
+            .modelType(FunctionName.SPARSE_TOKENIZE.name())
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+        final MLModel remoteSparseModel = MLModel.builder().algorithm(FunctionName.REMOTE).modelConfig(remoteSparseModelConfig).build();
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (remoteTextEmbeddingModelId.equals(modelId)) {
+                listener.onResponse(remoteTextEmbeddingModel);
+            } else if (remoteSparseModelId.equals(modelId)) {
+                listener.onResponse(remoteSparseModel);
+            } else {
+                listener.onFailure(new RuntimeException("Model not found"));
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // verify
+        final String expectedTransformedMappingString = Files.readString(
+            Path.of(classLoader.getResource("mapper/transformedMappingMultipleSemanticFields.json").toURI())
+        );
+
+        final Map<String, Object> expectedTransformedMapping = MapperService.parseMapping(
+            namedXContentRegistry,
+            expectedTransformedMappingString
+        );
+        assertEquals(expectedTransformedMapping, mappings);
+    }
+
+    public void testTransform_whenUnsupportedModelType_thenException() {
+        // prepare original mappings
+        final String unsupportedModelId = "unsupportedModelId";
+        final Map<String, Object> mappings = getBaseMappingsWithOneSemanticField(unsupportedModelId);
+
+        // prepare mock model config
+        final MLModel unsupportedModel = MLModel.builder().algorithm(FunctionName.QUESTION_ANSWERING).build();
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (unsupportedModelId.equals(modelId)) {
+                listener.onResponse(unsupportedModel);
+            } else {
+                listener.onFailure(new RuntimeException("Model not found"));
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage = "Failed to transform the mapping for the semantic field with model id "
+            + "unsupportedModelId at path semantic_field. QUESTION_ANSWERING is not supported.";
+        assertTrue(capturedException.getMessage().contains(expectedErrorMessage));
+    }
+
+    public void testTransform_whenWrongModelConfig_thenException() {
+        // prepare original mappings
+        final String dummyModelId = "dummyModelId";
+        final Map<String, Object> mappings = getBaseMappingsWithOneSemanticField(dummyModelId);
+
+        // prepare mock model config
+        QuestionAnsweringModelConfig questionAnsweringModelConfig = QuestionAnsweringModelConfig.builder()
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(QuestionAnsweringModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+        final MLModel dummyModel = MLModel.builder().algorithm(FunctionName.REMOTE).modelConfig(questionAnsweringModelConfig).build();
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (dummyModelId.equals(modelId)) {
+                listener.onResponse(dummyModel);
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage =
+            "Failed to transform the mapping for the semantic field with model id dummyModelId at path semantic_field. remote model is text embedding but model config is not a text embedding config.";
+        assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    public void testTransform_whenRemoteModelMissingEmbeddingDimension_thenException() {
+        // prepare original mappings
+        final String dummyModelId = "dummyModelId";
+        final Map<String, Object> mappings = getBaseMappingsWithOneSemanticField(dummyModelId);
+
+        // prepare mock model config
+        final TextEmbeddingModelConfig remoteTextEmbeddingModelConfig = mock(TextEmbeddingModelConfig.class);
+        final MLModel dummyModel = MLModel.builder().algorithm(FunctionName.REMOTE).modelConfig(remoteTextEmbeddingModelConfig).build();
+
+        // mock
+        when(remoteTextEmbeddingModelConfig.getModelType()).thenReturn(FunctionName.TEXT_EMBEDDING.name());
+        when(remoteTextEmbeddingModelConfig.getEmbeddingDimension()).thenReturn(null);
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (dummyModelId.equals(modelId)) {
+                listener.onResponse(dummyModel);
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage =
+            "Failed to transform the mapping for the semantic field with model id dummyModelId at path semantic_field. remote model is text embedding but embedding dimension is not defined in the model config.";
+        assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    public void testTransform_whenRemoteModelMissingSpaceType_thenException() {
+        // prepare original mappings
+        final String dummyModelId = "dummyModelId";
+        final Map<String, Object> mappings = getBaseMappingsWithOneSemanticField(dummyModelId);
+
+        // prepare mock model config
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{}";
+        final TextEmbeddingModelConfig remoteTextEmbeddingModelConfig = TextEmbeddingModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(TextEmbeddingModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .build();
+        final MLModel remoteTextEmbeddingModel = MLModel.builder()
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteTextEmbeddingModelConfig)
+            .build();
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (dummyModelId.equals(modelId)) {
+                listener.onResponse(remoteTextEmbeddingModel);
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage =
+            "Failed to transform the mapping for the semantic field with model id dummyModelId at path semantic_field. space_type is not defined or not a string in the all config of the model.";
+        assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    public void testTransform_whenModelNotFound_thenException() {
+        // prepare original mappings
+        final String notFoundModelId = "notFoundModelId";
+        final Map<String, Object> mappings = getBaseMappingsWithOneSemanticField(notFoundModelId);
+
+        // mock
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (notFoundModelId.equals(modelId)) {
+                listener.onFailure(new RuntimeException("Model not found"));
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage = "Failed to transform mapping for semantic fields because failed to get "
+            + "the model info of the model id notFoundModelId. Model not found";
+        assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    public void testTransform_whenInvalidCustomSemanticInfoFieldName_thenException() {
+        // prepare original mappings
+        final String dummyModelId = "dummyModelId";
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticFiled = new HashMap<>();
+        properties.put("semantic_field", semanticFiled);
+        semanticFiled.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled.put(SemanticFieldConstants.MODEL_ID, dummyModelId);
+        semanticFiled.put(SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME, new ArrayList<>());
+
+        // mock
+        final MLModel sparseModel = MLModel.builder().algorithm(FunctionName.SPARSE_ENCODING).build();
+
+        doAnswer(invocationOnMock -> {
+            final String modelId = invocationOnMock.getArgument(0);
+            final ActionListener<MLModel> listener = invocationOnMock.getArgument(1);
+            if (dummyModelId.equals(modelId)) {
+                listener.onResponse(sparseModel);
+            }
+            return null;
+        }).when(mlClientAccessor).getModel(any(), any());
+
+        // call
+        transformer.transform(mappings, null, listener);
+
+        // Capture the exception passed to onFailure
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        // Then: Assert that the exception message is as expected
+        final Exception capturedException = exceptionCaptor.getValue();
+        final String expectedErrorMessage =
+            "Failed to transform the mapping for the semantic field with model id dummyModelId at path semantic_field. semantic_info_field_name should be a string for the semantic field at: semantic_field.";
+        assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    private Map<String, Object> getBaseMappingsWithOneSemanticField(@NonNull final String modelId) {
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticFiled = new HashMap<>();
+        properties.put("semantic_field", semanticFiled);
+        semanticFiled.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticFiled.put(SemanticFieldConstants.MODEL_ID, modelId);
+        return mappings;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingUtilsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingUtilsTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mappingtransformer;
+
+import joptsimple.internal.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SemanticMappingUtilsTests extends OpenSearchTestCase {
+    private final ClassLoader classLoader = this.getClass().getClassLoader();
+    private final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());
+
+    public void testCollectSemanticField() throws URISyntaxException, IOException {
+        final String expectedTransformedMappingString = Files.readString(
+            Path.of(classLoader.getResource("mapper/mappingWithNestedSemanticFields.json").toURI())
+        );
+
+        final Map<String, Object> originalMapping = MapperService.parseMapping(namedXContentRegistry, expectedTransformedMappingString);
+        final Map<String, Map<String, Object>> semanticFieldPathToConfigMap = new HashMap<>();
+
+        SemanticMappingUtils.collectSemanticField(originalMapping, Strings.EMPTY, semanticFieldPathToConfigMap);
+
+        final Map<String, Map<String, Object>> expectedPathToConfigMap = Map.of(
+            "products.product_description",
+            Map.of("model_id", "dummy model id", "type", "semantic")
+        );
+        assertEquals(expectedPathToConfigMap, semanticFieldPathToConfigMap);
+    }
+
+    public void testExtractModelIdToFieldPathMap() {
+        final Map<String, Map<String, Object>> semanticFieldPathToConfigMap = Map.of(
+            "semantic_field_1",
+            Map.of("model_id", "dummy model id", "type", "semantic"),
+            "semantic_field_2",
+            Map.of("model_id", "dummy model id", "type", "semantic"),
+            "semantic_field_3",
+            Map.of("model_id", "dummy model id 3", "type", "semantic")
+        );
+
+        final Map<String, List<String>> modelIdToFieldPathMap = SemanticMappingUtils.extractModelIdToFieldPathMap(
+            semanticFieldPathToConfigMap
+        );
+        modelIdToFieldPathMap.get("dummy model id").sort(String::compareTo);
+
+        final Map<String, List<String>> expectedPathToFieldPathMap = Map.of(
+            "dummy model id",
+            List.of("semantic_field_1", "semantic_field_2"),
+            "dummy model id 3",
+            List.of("semantic_field_3")
+        );
+
+        assertEquals(expectedPathToFieldPathMap, modelIdToFieldPathMap);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.ml;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.model.MLResultDataType;
@@ -65,9 +67,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSentence(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST.get(0), singleSentenceResultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(singleSentenceResultListener).onResponse(vector);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(singleSentenceResultListener).onResponse(vector);
         Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
     }
 
@@ -81,9 +82,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onResponse(vectorList);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener).onResponse(vectorList);
         Mockito.verifyNoMoreInteractions(resultListener);
     }
 
@@ -97,9 +97,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onResponse(vectorList);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener).onResponse(vectorList);
         Mockito.verifyNoMoreInteractions(resultListener);
     }
 
@@ -112,9 +111,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onFailure(exception);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener).onFailure(exception);
         Mockito.verifyNoMoreInteractions(resultListener);
     }
 
@@ -133,11 +131,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, similarityResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
-        Mockito.verify(client, times(4))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(client, times(4)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
 
         // Verify failure is propagated to the listener after all retries
-        Mockito.verify(similarityResultListener).onFailure(nodeNodeConnectedException);
+        verify(similarityResultListener).onFailure(nodeNodeConnectedException);
 
         // Ensure no additional interactions with the listener
         Mockito.verifyNoMoreInteractions(similarityResultListener);
@@ -155,9 +156,12 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client, times(4))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onFailure(nodeNodeConnectedException);
+        verify(client, times(4)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
+        verify(resultListener).onFailure(nodeNodeConnectedException);
     }
 
     public void testInferenceSentences_whenNotConnectionException_thenNoRetry() {
@@ -169,9 +173,12 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client, times(1))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onFailure(illegalStateException);
+        verify(client, times(1)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
+        verify(resultListener).onFailure(illegalStateException);
     }
 
     public void testInferenceSentencesWithMapResult_whenValidInput_thenSuccess() {
@@ -184,9 +191,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onResponse(List.of(map));
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener).onResponse(List.of(map));
         Mockito.verifyNoMoreInteractions(resultListener);
     }
 
@@ -200,10 +206,9 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
-        Mockito.verify(resultListener).onFailure(argumentCaptor.capture());
+        verify(resultListener).onFailure(argumentCaptor.capture());
         assertEquals(
             "Empty model result produced. Expected at least [1] tensor output and [1] model tensor, but got [0]",
             argumentCaptor.getValue().getMessage()
@@ -224,10 +229,9 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
-        Mockito.verify(resultListener).onFailure(argumentCaptor.capture());
+        verify(resultListener).onFailure(argumentCaptor.capture());
         assertEquals(
             "Empty model result produced. Expected at least [1] tensor output and [1] model tensor, but got [0]",
             argumentCaptor.getValue().getMessage()
@@ -251,9 +255,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onResponse(List.of(Map.of("key", "value"), Map.of("key", "value")));
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener).onResponse(List.of(Map.of("key", "value"), Map.of("key", "value")));
         Mockito.verifyNoMoreInteractions(resultListener);
     }
 
@@ -270,9 +273,12 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client, times(4))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onFailure(nodeNodeConnectedException);
+        verify(client, times(4)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
+        verify(resultListener).onFailure(nodeNodeConnectedException);
     }
 
     public void testInferenceSentencesWithMapResult_whenNotRetryableException_thenFail() {
@@ -285,9 +291,12 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
-        Mockito.verify(client, times(1))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(resultListener).onFailure(illegalStateException);
+        verify(client, times(1)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
+        verify(resultListener).onFailure(illegalStateException);
     }
 
     public void testInferenceMultimodal_whenValidInput_thenSuccess() {
@@ -300,9 +309,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(singleSentenceResultListener).onResponse(vector);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(singleSentenceResultListener).onResponse(vector);
         Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
     }
 
@@ -321,11 +329,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
-        Mockito.verify(client, times(4))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(client, times(4)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
 
         // Verify failure is propagated to the listener after retries
-        Mockito.verify(singleSentenceResultListener).onFailure(nodeNodeConnectedException);
+        verify(singleSentenceResultListener).onFailure(nodeNodeConnectedException);
 
         // Verify no further interactions with the listener
         Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
@@ -343,9 +354,12 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
-        Mockito.verify(client, times(4))
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(singleSentenceResultListener).onFailure(nodeNodeConnectedException);
+        verify(client, times(4)).predict(
+            Mockito.eq(TestCommonConstants.MODEL_ID),
+            Mockito.isA(MLInput.class),
+            Mockito.isA(ActionListener.class)
+        );
+        verify(singleSentenceResultListener).onFailure(nodeNodeConnectedException);
     }
 
     public void testInferenceSimilarity_whenValidInput_thenSuccess() {
@@ -358,9 +372,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, similarityResultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(similarityResultListener).onResponse(vector);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(similarityResultListener).onResponse(vector);
         Mockito.verifyNoMoreInteractions(similarityResultListener);
     }
 
@@ -374,9 +387,8 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, similarityResultListener);
 
-        Mockito.verify(client)
-            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        Mockito.verify(similarityResultListener).onFailure(exception);
+        verify(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(similarityResultListener).onFailure(exception);
         Mockito.verifyNoMoreInteractions(similarityResultListener);
     }
 
@@ -423,5 +435,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }
         ModelTensorOutput modelTensorOutput = new ModelTensorOutput(tensorsList);
         return modelTensorOutput;
+    }
+
+    public void testGetModel_Success() {
+        final String modelId = "someModelId";
+        final ActionListener<MLModel> listener = mock(ActionListener.class);
+
+        accessor.getModel(modelId, listener);
+
+        verify(client).getModel(modelId, null, listener);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -202,4 +202,8 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
     public void testGetMappers_shouldReturnEmptyMap() {
         assertTrue(plugin.getMappers().isEmpty());
     }
+
+    public void testGetMappingTransformers_shouldReturnEmptyMap() {
+        assertTrue(plugin.getMappingTransformers().isEmpty());
+    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -198,4 +198,8 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         assertEquals("Unexpected number of executor builders are registered", 1, executorBuilders.size());
         assertTrue(executorBuilders.get(0) instanceof FixedExecutorBuilder);
     }
+
+    public void testGetMappers_shouldReturnEmptyMap() {
+        assertTrue(plugin.getMappers().isEmpty());
+    }
 }

--- a/src/test/resources/mapper/mappingWithNestedSemanticFields.json
+++ b/src/test/resources/mapper/mappingWithNestedSemanticFields.json
@@ -1,0 +1,14 @@
+{
+  "products": {
+    "type": "nested",
+    "properties": {
+      "product_description": {
+        "type": "semantic",
+        "model_id": "dummy model id"
+      },
+      "price": {
+        "type": "number"
+      }
+    }
+  }
+}

--- a/src/test/resources/mapper/transformedMappingMultipleSemanticFields.json
+++ b/src/test/resources/mapper/transformedMappingMultipleSemanticFields.json
@@ -1,0 +1,82 @@
+
+{
+  "properties": {
+    "semantic_field_1": {
+      "model_id": "textEmbeddingModelId",
+      "type": "semantic"
+    },
+    "semantic_field_2": {
+      "model_id": "sparseModelId",
+      "type": "semantic",
+      "semantic_info_field_name": "custom_semantic_info_field"
+    },
+    "custom_semantic_info_field": {
+      "properties": {
+        "chunks": {
+          "type": "nested",
+          "properties": {
+            "embedding": {
+              "type": "rank_feature"
+            },
+            "text": {
+              "type": "text"
+            }
+          }
+        },
+        "model": {
+          "properties": {
+            "id": {
+              "type": "text",
+              "index": false
+            },
+            "type": {
+              "type": "text",
+              "index": false
+            },
+            "name": {
+              "type": "text",
+              "index": false
+            }
+          }
+        }
+      }
+    },
+    "semantic_field_1_semantic_info": {
+      "properties": {
+        "chunks": {
+          "type": "nested",
+          "properties": {
+            "embedding": {
+              "type": "knn_vector",
+              "method": {
+                "engine": "faiss",
+                "space_type": "l2",
+                "name": "hnsw"
+              },
+              "dimension": 768
+            },
+            "text": {
+              "type": "text"
+            }
+          }
+        },
+        "model": {
+          "properties": {
+            "id": {
+              "type": "text",
+              "index": false
+            },
+            "type": {
+              "type": "text",
+              "index": false
+            },
+            "name": {
+              "type": "text",
+              "index": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Add semantic mapping transformer to transform mapping for semantic fields.

It will auto add semantic info fields to the mapping based on the model id defined in the semantic fields.

### Note
This PR is based on this [one](https://github.com/opensearch-project/neural-search/pull/1225/files). And it's not target the main branch of the neural plugin main. It's just for review purpose.

### Related Issues
[#[803]](https://github.com/opensearch-project/neural-search/issues/803) - Proposal to support semantic field in neural search.
[#[1211]](https://github.com/opensearch-project/neural-search/issues/1211) - HLD of the semantic field.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
